### PR TITLE
Auths

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,9 +1,11 @@
 import com.google.inject.AbstractModule
 
+import auth.{UserRefiner, UserRefinerImpl}
 import cafe.{CafeRepository, MockCafeRepository}
 
 class Module extends AbstractModule {
   override def configure(): Unit = {
+    bind(classOf[UserRefiner]).to(classOf[UserRefinerImpl])
     bind(classOf[CafeRepository]).to(classOf[MockCafeRepository])
   }
 }

--- a/app/auth/Token.scala
+++ b/app/auth/Token.scala
@@ -1,3 +1,0 @@
-package auth
-
-case class Token(value: String)

--- a/app/auth/Token.scala
+++ b/app/auth/Token.scala
@@ -1,0 +1,3 @@
+package auth
+
+case class Token(value: String)

--- a/app/auth/User.scala
+++ b/app/auth/User.scala
@@ -1,0 +1,6 @@
+package auth
+
+case class User(
+  id: Long,
+  name: String
+)

--- a/app/auth/UserRefiner.scala
+++ b/app/auth/UserRefiner.scala
@@ -1,0 +1,13 @@
+package auth
+
+import javax.inject.Inject
+import play.api.mvc.{Request, Result, ActionRefiner}
+import scala.concurrent.{Future, ExecutionContext}
+
+abstract class UserRefiner @Inject()(ec: ExecutionContext)
+  extends ActionRefiner[Request, UserRequest] {
+
+  override def executionContext = ec
+  protected def refine[A](request: Request[A]): Future[Either[Result, UserRequest[A]]]
+
+}

--- a/app/auth/UserRefinerImpl.scala
+++ b/app/auth/UserRefinerImpl.scala
@@ -1,0 +1,40 @@
+package auth
+
+import javax.inject.{Singleton, Inject}
+import play.api.mvc.{Request, Result}
+import scala.concurrent.{Future, ExecutionContext}
+import play.api.mvc.Results
+import cats.data.EitherT
+import cats.implicits._
+
+@Singleton
+class UserRefinerImpl @Inject()(
+  implicit ec: ExecutionContext,
+  userRepository: UserRepository
+) extends UserRefiner(ec) {
+
+  protected def refine[A](request: Request[A]):
+    Future[Either[Result, UserRequest[A]]] = {
+
+    def requestFilter(): Future[Either[Result, String]] = Future.successful {
+      request.headers.get("Authorization") match {
+        case Some(token) => Right(token)
+        case None => Left(Results.BadRequest)
+      }
+    }
+
+    def checkToken(token: String): Future[Either[Result, UserRequest[A]]] = {
+      userRepository.findByToken(token).map {
+        case Some(user) => Right(new UserRequest(user, request))
+        case None => Left(Results.BadRequest)
+      }
+    }
+
+    val et: EitherT[Future, Result, UserRequest[A]] = for {
+      token <- EitherT(requestFilter())
+      userRequest <- EitherT(checkToken(token))
+    } yield userRequest
+    et.value
+  }
+
+}

--- a/app/auth/UserRepository.scala
+++ b/app/auth/UserRepository.scala
@@ -1,0 +1,9 @@
+package auth
+
+import scala.concurrent.Future
+
+trait UserRepository {
+
+  def findByToken(token: String): Future[Option[User]]
+
+}

--- a/app/auth/UserRepositoryImpl.scala
+++ b/app/auth/UserRepositoryImpl.scala
@@ -1,0 +1,42 @@
+package auth
+
+import javax.inject.{Singleton, Inject}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scalikejdbc._
+import scala.concurrent.duration._
+
+@Singleton
+class UserRepositoryImpl @Inject()(
+  implicit ec: ExecutionContext
+) extends UserRepository {
+
+  implicit val session = AutoSession
+  val tokenExpirationDuration = 1.day
+
+  def findByToken(token: String): Future[Option[User]] = {
+    def mkUserEntity(rs: WrappedResultSet) = User(
+      id = rs.get("id"),
+      name = rs.get("name")
+    )
+
+    Future {
+      sql"""
+        select u.id as id, u.name as name
+          from tokens as t
+            inner join auths as a
+              on t.auth_id = a.id
+            inner join users as u
+              on a.id = u.auth_id
+          where
+            token = ${token}
+            and created_at >= current_timestamp - interval ${tokenExpirationDuration.toMinutes} minute;
+      """
+        .map(rs => mkUserEntity(rs))
+        .single.apply()
+    }
+
+  }
+
+  
+}

--- a/app/auth/UserRequest.scala
+++ b/app/auth/UserRequest.scala
@@ -1,0 +1,6 @@
+package auth
+
+import play.api.mvc.{Request, WrappedRequest}
+
+class UserRequest[A](val user: User, request: Request[A])
+  extends WrappedRequest[A](request)


### PR DESCRIPTION
例えば `app/cafe/CafeController.scala` で

```
package cafe

import javax.inject.{Singleton, Inject}
import play.api.mvc._
import auth.UserRefiner

import utils.CirceWritable._

@Singleton
class CafeController @Inject()(
  cc: ControllerComponents,
  userRefiner: UserRefiner,
  cafeRepository: CafeRepository,
) extends AbstractController(cc) {

  implicit val ec = cc.executionContext

  def all() = Action.andThen(userRefiner).async { request =>
  
    cafeRepository.findAll.map { cafes =>
      Ok(CafeResponse.fromSeq(cafes))
    }

  }

}
```

と指定すると、 `request` に Userの id, name のフィールドが生えます

`app/auth/UserRepositoryImpl.scala` の実装は適当です、あとでDB決めながら直します